### PR TITLE
Expand ESLint support for TypeScript and add max-warnings CLI option

### DIFF
--- a/.changeset/cruel-breads-read.md
+++ b/.changeset/cruel-breads-read.md
@@ -1,0 +1,5 @@
+---
+'@tcd-devkit/eslint-config-ts': patch
+---
+
+Fix ESLint errors

--- a/.changeset/khaki-pigs-wink.md
+++ b/.changeset/khaki-pigs-wink.md
@@ -1,0 +1,5 @@
+---
+'@tcd-devkit/eslint-preset-node': patch
+---
+
+Properly configure Node ENV

--- a/.changeset/salty-pianos-write.md
+++ b/.changeset/salty-pianos-write.md
@@ -1,0 +1,5 @@
+---
+'@tcd-devkit/scripts': patch
+---
+
+Add max-warnings arg for ESLint

--- a/.changeset/solid-lands-tickle.md
+++ b/.changeset/solid-lands-tickle.md
@@ -1,0 +1,6 @@
+---
+'@tcd-devkit/eslint-config-import': patch
+'@tcd-devkit/eslint-config': patch
+---
+
+Add missing TypeScript file extensions

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,4 @@
-/**
- * @type {import('@commitlint/types').UserConfig}
- */
+/** @type {import('@commitlint/types').UserConfig} */
 export default {
   extends: ['@tcd-devkit'],
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@changesets/changelog-github": "0.5.1",
     "@changesets/cli": "2.29.4",
     "@commitlint/cli": "19.8.1",
+    "@commitlint/types": "19.8.1",
     "@tcd-devkit/commitlint-config": "workspace:*",
     "@tcd-devkit/eslint-preset-node": "workspace:*",
     "@tcd-devkit/prettier-config": "workspace:*",

--- a/packages/eslint-presets/eslint-preset-node/package.json
+++ b/packages/eslint-presets/eslint-preset-node/package.json
@@ -59,7 +59,8 @@
     "@tcd-devkit/eslint-config": "workspace:*",
     "@tcd-devkit/eslint-config-import-ts": "workspace:*",
     "@tcd-devkit/eslint-config-ts": "workspace:*",
-    "eslint-config-prettier": "10.1.5"
+    "eslint-config-prettier": "10.1.5",
+    "globals": "16.2.0"
   },
   "devDependencies": {
     "@tcd-devkit/scripts": "workspace:*",

--- a/packages/eslint-presets/eslint-preset-node/src/node-preset.linter.ts
+++ b/packages/eslint-presets/eslint-preset-node/src/node-preset.linter.ts
@@ -1,6 +1,7 @@
 import type { Linter } from 'eslint';
 import prettierConfig from 'eslint-config-prettier/flat';
 import { defineConfig, globalIgnores } from 'eslint/config';
+import globals from 'globals';
 
 import { baseConfig } from '@tcd-devkit/eslint-config';
 import { importTsConfig } from '@tcd-devkit/eslint-config-import-ts';
@@ -14,6 +15,11 @@ const ignoresConfig = globalIgnores(
 export const nodePreset: Linter.Config[] = defineConfig([
   {
     name: '@tcd-devkit/eslint-preset-node',
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
     extends: [baseConfig, tsConfig, importTsConfig],
   },
   prettierConfig,

--- a/packages/eslint/eslint-config-import/src/import.linter.ts
+++ b/packages/eslint/eslint-config-import/src/import.linter.ts
@@ -9,7 +9,7 @@ const importRecommended = importPluginConfigs.recommended as Linter.Config;
 export const importConfig = defineConfig({
   name: '@tcd-devkit/eslint-config-import',
   extends: [importRecommended],
-  files: ['**/*.{js,jsx,mjs,cjs}'],
+  files: ['**/*.{js,jsx,ts,tsx,mjs,cjs}'],
   rules: importRules,
 });
 

--- a/packages/eslint/eslint-config-ts/src/__tests__/rules/unbound-method.test.ts
+++ b/packages/eslint/eslint-config-ts/src/__tests__/rules/unbound-method.test.ts
@@ -9,10 +9,6 @@ describe(`${ruleId} rule`, () => {
   it('should have a disabled rule', () => {
     const ruleValue = tsRules[ruleId];
 
-    console.log('tsRules:', tsRules);
-    console.log('ruleId:', ruleId);
-    console.log('ruleValue:', ruleValue);
-
     expect(ruleValue).toEqual(['off']);
   });
 });

--- a/packages/eslint/eslint-config-ts/src/ts.rules.ts
+++ b/packages/eslint/eslint-config-ts/src/ts.rules.ts
@@ -22,6 +22,4 @@ export const tsRules = {
   ],
 } satisfies Linter.RulesRecord;
 
-console.log('source tsRules:', tsRules);
-
 export type CustomRule = keyof typeof tsRules;

--- a/packages/eslint/eslint-config/src/base.linter.ts
+++ b/packages/eslint/eslint-config/src/base.linter.ts
@@ -24,7 +24,7 @@ export const baseConfig: Linter.Config[] = defineConfig([
   {
     name: '@tcd-devkit/eslint-config',
     extends: [eslintPlugin.configs.recommended],
-    files: ['**/*.{js,jsx,mjs,cjs}'],
+    files: ['**/*.{js,jsx,ts,tsx,mjs,cjs}'],
     rules: baseRules,
   },
 ]);

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -64,11 +64,12 @@ Runs ESLint, Prettier (check mode), and TypeScript type checking.
 - `--refresh-cache`: Force refresh of the cache.
 - `--ignore-path <path>`: Path to a custom ignore file (e.g., `.myignore`).
 - `--project <path>`: Path to your `tsconfig.json` or equivalent TypeScript project file. (e.g., `tcd-scripts lint --project ./tsconfig.build.json`)
+- `--max-warnings <number>`: Maximum number of warnings allowed before failing. (Default: 0)
 
 **Example:**
 
 ```bash
-tcd-scripts lint ./src ./tests --only eslint --project ./tsconfig.lint.json
+tcd-scripts lint ./src ./tests --only eslint --project ./tsconfig.lint.json --max-warnings 10
 ```
 
 #### `tcd-scripts format [files...]` (alias: `tcd-scripts f`)

--- a/packages/scripts/src/commands/format.command.ts
+++ b/packages/scripts/src/commands/format.command.ts
@@ -26,7 +26,6 @@ export const registerFormatCommand = (program: Command) => {
     .addOption(noCacheOption)
     .addOption(refreshCacheOption)
     .addOption(ignorePathOption)
-
     .action(async (files: string[], options: FormatCommandOptions) => {
       const toolsToRun = getToolsToRun(FORMAT_TOOLS, options);
       let overallSuccess = true;

--- a/packages/scripts/src/commands/lint.command.ts
+++ b/packages/scripts/src/commands/lint.command.ts
@@ -5,6 +5,7 @@ import {
   ignorePathOption,
   lintOnlyOption,
   lintSkipOption,
+  maxWarningsOption,
   noCacheOption,
   projectOption,
   refreshCacheOption,
@@ -31,6 +32,7 @@ export const registerLintCommand = (program: Command) => {
     .addOption(refreshCacheOption)
     .addOption(ignorePathOption)
     .addOption(projectOption)
+    .addOption(maxWarningsOption)
     .action(async (files, options: LintCommandOptions) => {
       const toolsToRun = getToolsToRun(LINT_TOOLS, options);
       let overallSuccess = true;

--- a/packages/scripts/src/constants/option.constants.ts
+++ b/packages/scripts/src/constants/option.constants.ts
@@ -54,6 +54,11 @@ export const ignorePathOption = new Option(
   'Path to ignore file for Prettier',
 );
 
+export const maxWarningsOption = new Option(
+  '--max-warnings <number>',
+  'Maximum number of warnings allowed before failing',
+).default('0');
+
 export const projectOption = new Option(
   '--project <path>',
   'Path to TS config for TSC',

--- a/packages/scripts/src/types/option.types.ts
+++ b/packages/scripts/src/types/option.types.ts
@@ -9,6 +9,7 @@ interface BaseCommandOptions {
   refreshCache?: boolean;
   cacheLocation?: string;
   ignorePath?: string;
+  maxWarnings?: string;
 }
 
 export interface ToolSelectionOptions<TTool extends string> {

--- a/packages/scripts/src/utils/cli.utils.ts
+++ b/packages/scripts/src/utils/cli.utils.ts
@@ -157,6 +157,9 @@ export const runEslint = async (
   const eslintArgs = [];
 
   if (isFix) eslintArgs.push('--fix');
+  if (options.maxWarnings !== undefined) {
+    eslintArgs.push('--max-warnings', options.maxWarnings.toString());
+  }
 
   await handleCache(options, eslintArgs, './.eslintcache');
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       eslint-config-prettier:
         specifier: 10.1.5
         version: 10.1.5(eslint@9.27.0(jiti@2.4.2))
+      globals:
+        specifier: 16.2.0
+        version: 16.2.0
     devDependencies:
       '@tcd-devkit/scripts':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@commitlint/cli':
         specifier: 19.8.1
         version: 19.8.1(@types/node@22.15.24)(typescript@5.8.3)
+      '@commitlint/types':
+        specifier: 19.8.1
+        version: 19.8.1
       '@tcd-devkit/commitlint-config':
         specifier: workspace:*
         version: link:packages/commitlint-config

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,4 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-call
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const config = require('@tcd-devkit/prettier-config');
 
 /** @type {import('prettier').Config} */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `--max-warnings` option to the lint command, allowing users to set a maximum number of warnings before the process fails.
  - ESLint configurations now include TypeScript file extensions, expanding linting coverage to `.ts` and `.tsx` files.
  - Improved Node.js environment support in ESLint presets by explicitly defining Node.js global variables.

- **Bug Fixes**
  - Addressed missing TypeScript file extensions in ESLint configurations.
  - Fixed ESLint errors in TypeScript ESLint config.

- **Documentation**
  - Updated documentation to reflect the new `--max-warnings` lint option.

- **Chores**
  - Added new development dependency for commit linting.
  - Minor comment and formatting cleanups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->