### PR TITLE
Update eslint-config-ts to disable attribute checking for void promises

### DIFF
--- a/.changeset/many-numbers-fry.md
+++ b/.changeset/many-numbers-fry.md
@@ -1,0 +1,5 @@
+---
+'@tcd-devkit/eslint-config-ts': patch
+---
+
+Disable attribute checking for void promises

--- a/packages/eslint/eslint-config-ts/src/__tests__/rules/no-misused-promises.test.ts
+++ b/packages/eslint/eslint-config-ts/src/__tests__/rules/no-misused-promises.test.ts
@@ -1,0 +1,155 @@
+import type { Linter } from 'eslint';
+import { config as defineConfig } from 'typescript-eslint';
+import { describe, expect, it } from 'vitest';
+
+import { getLintMessagesForRule } from '@tcd-devkit/internal-utils/test';
+import type { GetLintMessagesOptions } from '@tcd-devkit/internal-utils/test';
+
+import { tsConfig } from '#ts.linter';
+import type { CustomRule } from '#ts.rules';
+
+const safeTsConfig = defineConfig(tsConfig, {
+  languageOptions: {
+    parserOptions: {
+      projectService: true,
+      tsconfigRootDir: process.cwd(),
+    },
+  },
+}) as Linter.Config[];
+
+const ruleId: CustomRule = '@typescript-eslint/no-misused-promises';
+
+const lintTextOptions: GetLintMessagesOptions = {
+  eslintOptions: {
+    cwd: import.meta.dirname,
+  },
+  lintTextOptions: {
+    filePath: './fixtures/fixture.ts',
+  },
+};
+
+describe(`${ruleId} rule`, () => {
+  it('should FAIL when using as a conditional (checksConditionals: true)', async () => {
+    const code = `
+      const promise = Promise.resolve('value');
+
+      const val = promise ? 123 : 456;
+    `;
+    const messages = await getLintMessagesForRule(
+      safeTsConfig,
+      code,
+      ruleId,
+      lintTextOptions,
+    );
+
+    expect(messages).toHaveLength(1);
+  });
+
+  it('should FAIL when using as spread (checksSpreads: true)', async () => {
+    const code = `
+      const getData = () => fetch('/');
+
+      console.log({ foo: 42, ...getData() });
+    `;
+    const messages = await getLintMessagesForRule(
+      safeTsConfig,
+      code,
+      ruleId,
+      lintTextOptions,
+    );
+
+    expect(messages).toHaveLength(1);
+  });
+
+  it('should FAIL when promises are void (checksVoidReturn: true)', async () => {
+    const code = `
+      new Promise<void>(async (resolve, reject) => {
+        await fetch('/');
+        resolve();
+      });
+    `;
+    const messages = await getLintMessagesForRule(
+      safeTsConfig,
+      code,
+      ruleId,
+      lintTextOptions,
+    );
+
+    expect(messages).toHaveLength(1);
+  });
+
+  it('should PASS when using properly with conditional (checksConditionals: true)', async () => {
+    const code = `
+      const promise = Promise.resolve('value');
+
+      const val = (await promise) ? 123 : 456;
+    `;
+    const messages = await getLintMessagesForRule(
+      safeTsConfig,
+      code,
+      ruleId,
+      lintTextOptions,
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  it('should PASS when using properly with spread (checksSpreads: true)', async () => {
+    const code = `
+      const getData = () => fetch('/');
+
+      console.log({ foo: 42, ...(await getData()) });
+    `;
+    const messages = await getLintMessagesForRule(
+      safeTsConfig,
+      code,
+      ruleId,
+      lintTextOptions,
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  it('should PASS when properly using void promises (checksVoidReturn: true)', async () => {
+    const code = `
+      new Promise((resolve, reject) => {
+        void (async () => {
+          await doSomething();
+          resolve();
+        })();
+      });
+    `;
+    const messages = await getLintMessagesForRule(
+      safeTsConfig,
+      code,
+      ruleId,
+      lintTextOptions,
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  it('should PASS when using void promise in an attribute (checksVoidReturn: { attributes: false })', async () => {
+    const code = `
+      const promise = async (): Promise<void> => {
+        await doSomething();
+      };
+
+      const MyComponent = () => {
+        return (
+          <form onSubmit={promise}>
+            <button type="submit">Submit</button>
+          </form>
+        );
+      };
+    `;
+    const messages = await getLintMessagesForRule(
+      safeTsConfig,
+      code,
+      ruleId,
+      lintTextOptions,
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+});

--- a/packages/eslint/eslint-config-ts/src/ts.rules.ts
+++ b/packages/eslint/eslint-config-ts/src/ts.rules.ts
@@ -11,6 +11,14 @@ export const tsRules = {
   '@typescript-eslint/naming-convention': ['off'],
   '@typescript-eslint/unbound-method': ['off'],
   '@typescript-eslint/no-loop-func': ['error'],
+  '@typescript-eslint/no-misused-promises': [
+    'error',
+    {
+      checksVoidReturn: {
+        attributes: false,
+      },
+    },
+  ],
   '@typescript-eslint/no-use-before-define': ['error'],
   '@typescript-eslint/return-await': ['error'],
   '@typescript-eslint/switch-exhaustiveness-check': [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated ESLint configuration to improve handling of promises in TypeScript projects, specifically disabling attribute checking for void promises.
- **Tests**
  - Added comprehensive tests to verify correct enforcement and exceptions for the new promise handling rule.
- **Chores**
  - Added documentation for the patch update in the changeset file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->