### PR TITLE
Add @tcd-devkit/eslint-preset-react ESLint flat config preset

### DIFF
--- a/packages/eslint-presets/eslint-preset-react/README.md
+++ b/packages/eslint-presets/eslint-preset-react/README.md
@@ -1,0 +1,71 @@
+# @tcd-devkit/eslint-preset-react
+
+Comprehensive ESLint Flat Configuration Preset for React projects. This preset bundles a curated set of `@tcd-devkit` ESLint configurations to provide a complete linting solution for modern React applications, including React, TypeScript, accessibility (a11y), and import rules. It is designed for ESLint v9+ and its Flat Config system.
+
+## Features
+
+- **All-in-One React Setup**: Combines configurations for React, React Hooks, TypeScript, Imports (JS & TS), and JSX A11y.
+- **Opinionated Defaults**: Provides a strong, opinionated baseline for React projects.
+- **Easy Integration**: Simplifies ESLint setup by providing a single package to install and configure.
+- **Flat Config**: Utilizes ESLint's modern flat configuration format (ESLint v9+).
+
+This preset includes the following `@tcd-devkit` configurations:
+
+- `@tcd-devkit/eslint-config` (Base JavaScript rules)
+- `@tcd-devkit/eslint-config-ts` (TypeScript rules)
+- `@tcd-devkit/eslint-config-import` (JavaScript import rules)
+- `@tcd-devkit/eslint-config-import-ts` (TypeScript import rules)
+- `@tcd-devkit/eslint-config-react` (React rules)
+- `@tcd-devkit/eslint-config-react-hooks` (React Hooks rules)
+- `@tcd-devkit/eslint-config-a11y` (JSX Accessibility rules)
+
+## Installation
+
+```bash
+# Using npm
+npm install -D @tcd-devkit/eslint-preset-react eslint@^9.0.0
+
+# Using yarn
+yarn add -D @tcd-devkit/eslint-preset-react eslint@^9.0.0
+
+# Using pnpm
+pnpm add -D @tcd-devkit/eslint-preset-react eslint@^9.0.0
+```
+
+All necessary `@tcd-devkit/eslint-config-*` packages are direct dependencies of this preset and will be installed automatically.
+
+## Usage
+
+Import and use the preset in your `eslint.config.js` (or `.mjs`/`.cjs`) file:
+
+```javascript
+import reactPreset from '@tcd-devkit/eslint-preset-react'; // This is an array of config objects
+
+export default [
+  ...reactPreset,
+  {
+    // Your project-specific overrides or additional configurations can be added here.
+    // For example, to adjust parser options for TypeScript if your tsconfig.json is not in the root:
+    // files: ['**/*.ts', '**/*.tsx'],
+    // languageOptions: {
+    //   parserOptions: {
+    //     project: './path/to/your/tsconfig.json',
+    //   },
+    // },
+    rules: {
+      // example: '@typescript-eslint/no-explicit-any': 'warn',
+    },
+  },
+];
+```
+
+This preset exports an array of ESLint configuration objects. You should spread it (`...reactPreset`) into your top-level configuration array. The underlying configurations are designed to work together. Ensure your `tsconfig.json` is correctly set up for TypeScript linting to function optimally.
+
+## Rules
+
+This preset combines rules from all the included `@tcd-devkit/eslint-config-*` packages listed in the Features section.
+For a detailed view of all active rules in your project, you can run ESLint with the `--print-config` flag.
+
+## License
+
+MIT © [Nace Logar](https://thecodedestroyer.com)

--- a/packages/eslint-presets/eslint-preset-react/package.json
+++ b/packages/eslint-presets/eslint-preset-react/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "@tcd-devkit/eslint-preset-react",
+  "version": "0.1.0",
+  "description": "Comprehensive ESLint Flat Configuration Preset for React projects. This preset bundles various @tcd-devkit ESLint configurations for a complete React, TypeScript, and a11y linting setup.",
+  "keywords": [
+    "tcd-devkit",
+    "preset",
+    "eslint",
+    "eslintconfig",
+    "eslint-preset",
+    "lint",
+    "react",
+    "typescript",
+    "a11y",
+    "flat-config"
+  ],
+  "homepage": "https://github.com/thecodedestroyer/devkit",
+  "bugs": {
+    "url": "https://github.com/thecodedestroyer/devkit/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thecodedestroyer/devkit.git",
+    "directory": "packages/eslint-presets/eslint-preset-react"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "Nace Logar",
+    "email": "the.code.destroyer@gmail.com",
+    "url": "https://thecodedestroyer.com"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/react-preset.linter.d.ts",
+      "require": "./dist/react-preset.linter.cjs",
+      "import": "./dist/react-preset.linter.js"
+    }
+  },
+  "main": "./dist/react-preset.linter.cjs",
+  "module": "./dist/react-preset.linter.js",
+  "types": "./dist/react-preset.linter.d.ts",
+  "typesVersions": {
+    "*": {
+      ".": [
+        "./dist/react-preset.linter.d.ts"
+      ]
+    }
+  },
+  "files": [
+    "dist",
+    "!dist/**/*.d.ts.map"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "lint:types": "tcd-scripts lint --only=tsc"
+  },
+  "dependencies": {
+    "@tcd-devkit/eslint-config": "workspace:*",
+    "@tcd-devkit/eslint-config-a11y": "workspace:*",
+    "@tcd-devkit/eslint-config-import-ts": "workspace:*",
+    "@tcd-devkit/eslint-config-react": "workspace:*",
+    "@tcd-devkit/eslint-config-react-hooks": "workspace:*",
+    "@tcd-devkit/eslint-config-ts": "workspace:*",
+    "eslint-config-prettier": "10.1.8"
+  },
+  "devDependencies": {
+    "@tcd-devkit/scripts": "workspace:*",
+    "@tcd-devkit/tsconfig": "workspace:*",
+    "@tcd-devkit/tsup-config": "workspace:*",
+    "@types/node": "22.17.2",
+    "tsup": "8.5.0"
+  },
+  "peerDependencies": {
+    "eslint": "^9.0.0"
+  },
+  "engines": {
+    "node": ">=20.11.0 || >=21.2.0"
+  }
+}

--- a/packages/eslint-presets/eslint-preset-react/src/react-preset.linter.ts
+++ b/packages/eslint-presets/eslint-preset-react/src/react-preset.linter.ts
@@ -1,0 +1,33 @@
+import type { Linter } from 'eslint';
+import prettierConfig from 'eslint-config-prettier/flat';
+import { defineConfig, globalIgnores } from 'eslint/config';
+
+import { baseConfig } from '@tcd-devkit/eslint-config';
+import { a11yConfig } from '@tcd-devkit/eslint-config-a11y';
+import { importTsConfig } from '@tcd-devkit/eslint-config-import-ts';
+import { reactConfig } from '@tcd-devkit/eslint-config-react';
+import { reactHooksConfig } from '@tcd-devkit/eslint-config-react-hooks';
+import { tsConfig } from '@tcd-devkit/eslint-config-ts';
+
+const ignoresConfig = globalIgnores(
+  ['**/dist/**', '**/node_modules/**', '**/build/**'],
+  '@tcd-devkit/eslint-config/ignores',
+);
+
+export const reactPreset: Linter.Config[] = defineConfig(
+  {
+    name: '@tcd-devkit/eslint-preset-react',
+    extends: [
+      baseConfig,
+      tsConfig,
+      reactConfig,
+      reactHooksConfig,
+      a11yConfig,
+      importTsConfig,
+    ],
+  },
+  prettierConfig,
+  ignoresConfig,
+);
+
+export default reactPreset;

--- a/packages/eslint-presets/eslint-preset-react/tsconfig.build.json
+++ b/packages/eslint-presets/eslint-preset-react/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@tcd-devkit/tsconfig/build"
+}

--- a/packages/eslint-presets/eslint-preset-react/tsconfig.json
+++ b/packages/eslint-presets/eslint-preset-react/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@tcd-devkit/tsconfig/lib"
+}

--- a/packages/eslint-presets/eslint-preset-react/tsup.config.ts
+++ b/packages/eslint-presets/eslint-preset-react/tsup.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'tsup';
+
+import { tsupLibConfig } from '@tcd-devkit/tsup-config/lib';
+
+export default defineConfig(tsupLibConfig);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,49 @@ importers:
         specifier: 8.5.0
         version: 8.5.0(jiti@2.5.1)(postcss@8.5.6)(typescript@5.9.2)
 
+  packages/eslint-presets/eslint-preset-react:
+    dependencies:
+      '@tcd-devkit/eslint-config':
+        specifier: workspace:*
+        version: link:../../eslint/eslint-config
+      '@tcd-devkit/eslint-config-a11y':
+        specifier: workspace:*
+        version: link:../../eslint/eslint-config-a11y
+      '@tcd-devkit/eslint-config-import-ts':
+        specifier: workspace:*
+        version: link:../../eslint/eslint-config-import-ts
+      '@tcd-devkit/eslint-config-react':
+        specifier: workspace:*
+        version: link:../../eslint/eslint-config-react
+      '@tcd-devkit/eslint-config-react-hooks':
+        specifier: workspace:*
+        version: link:../../eslint/eslint-config-react-hooks
+      '@tcd-devkit/eslint-config-ts':
+        specifier: workspace:*
+        version: link:../../eslint/eslint-config-ts
+      eslint:
+        specifier: ^9.0.0
+        version: 9.34.0(jiti@2.5.1)
+      eslint-config-prettier:
+        specifier: 10.1.8
+        version: 10.1.8(eslint@9.34.0(jiti@2.5.1))
+    devDependencies:
+      '@tcd-devkit/scripts':
+        specifier: workspace:*
+        version: link:../../scripts
+      '@tcd-devkit/tsconfig':
+        specifier: workspace:*
+        version: link:../../tsconfig
+      '@tcd-devkit/tsup-config':
+        specifier: workspace:*
+        version: link:../../tsup-config
+      '@types/node':
+        specifier: 22.17.2
+        version: 22.17.2
+      tsup:
+        specifier: 8.5.0
+        version: 8.5.0(jiti@2.5.1)(postcss@8.5.6)(typescript@5.9.2)
+
   packages/eslint/eslint-config:
     dependencies:
       '@eslint/compat':
@@ -1236,6 +1279,9 @@ packages:
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
+  '@types/node@22.17.2':
+    resolution: {integrity: sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==}
 
   '@types/node@22.18.0':
     resolution: {integrity: sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==}
@@ -4073,6 +4119,10 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/node@12.20.55': {}
+
+  '@types/node@22.17.2':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@22.18.0':
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduced @tcd-devkit/eslint-preset-react: a flat-config ESLint preset bundling React, TypeScript, hooks, import, and accessibility rules with Prettier integration.

- Documentation
  - Added README with installation commands (npm/yarn/pnpm), usage example for top-level ESLint flat config, guidance for inspecting active rules, and TypeScript notes.

- Chores
  - Added packaging/build metadata, publishable artifacts, build/type scripts, ESLint peer dependency (v9+), and Node engine requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->