### PR TITLE
Add changeset, globals dep, and Node globals to React ESLint preset

### DIFF
--- a/.changeset/slick-geese-yawn.md
+++ b/.changeset/slick-geese-yawn.md
@@ -1,0 +1,5 @@
+---
+'@tcd-devkit/eslint-preset-react': patch
+---
+
+Add missing Node globals to React preset

--- a/packages/eslint-presets/eslint-preset-react/package.json
+++ b/packages/eslint-presets/eslint-preset-react/package.json
@@ -62,7 +62,8 @@
     "@tcd-devkit/eslint-config-react": "workspace:*",
     "@tcd-devkit/eslint-config-react-hooks": "workspace:*",
     "@tcd-devkit/eslint-config-ts": "workspace:*",
-    "eslint-config-prettier": "10.1.8"
+    "eslint-config-prettier": "10.1.8",
+    "globals": "16.3.0"
   },
   "devDependencies": {
     "@tcd-devkit/scripts": "workspace:*",

--- a/packages/eslint-presets/eslint-preset-react/src/react-preset.linter.ts
+++ b/packages/eslint-presets/eslint-preset-react/src/react-preset.linter.ts
@@ -1,6 +1,7 @@
 import type { Linter } from 'eslint';
 import prettierConfig from 'eslint-config-prettier/flat';
 import { defineConfig, globalIgnores } from 'eslint/config';
+import globals from 'globals';
 
 import { baseConfig } from '@tcd-devkit/eslint-config';
 import { a11yConfig } from '@tcd-devkit/eslint-config-a11y';
@@ -17,6 +18,11 @@ const ignoresConfig = globalIgnores(
 export const reactPreset: Linter.Config[] = defineConfig(
   {
     name: '@tcd-devkit/eslint-preset-react',
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
     extends: [
       baseConfig,
       tsConfig,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       eslint-config-prettier:
         specifier: 10.1.8
         version: 10.1.8(eslint@9.34.0(jiti@2.5.1))
+      globals:
+        specifier: 16.3.0
+        version: 16.3.0
     devDependencies:
       '@tcd-devkit/scripts':
         specifier: workspace:*


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - React ESLint preset now recognizes Node globals, reducing false “undefined variable” lint errors in Node/SSR contexts.

- Chores
  - Added patch release entry for the React ESLint preset.
  - Introduced a dependency to supply standard Node globals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->